### PR TITLE
[Add] 메인페이지 검색 기능 추가 및 라우터 설정

### DIFF
--- a/src/components/layouts/TheHeader.vue
+++ b/src/components/layouts/TheHeader.vue
@@ -9,7 +9,7 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
           <li class="nav-item">
-            <router-link class="nav-link active" aria-current="page" to="/search-jobs">Search Jobs</router-link>
+            <router-link class="nav-link active" aria-current="page" to="/search-jobs/1">Search Jobs</router-link>
           </li>
           <li class="nav-item">
             <router-link class="nav-link" to="/">Review</router-link>

--- a/src/components/mainpage/MainCardList.vue
+++ b/src/components/mainpage/MainCardList.vue
@@ -27,7 +27,7 @@
       </ul>
     </base-card>
   </li>
-  <router-link to="/search-jobs"><div class="view-more">view more</div></router-link>
+  <router-link to="/search-jobs/1"><div class="view-more">view more</div></router-link>
 </template>
 
 <script>

--- a/src/components/mainpage/MainPage.vue
+++ b/src/components/mainpage/MainPage.vue
@@ -1,8 +1,8 @@
 <template>
-    <search-section @articles-loaded="updateArticles"></search-section>
+    <!-- SearchSection.vue에서 emits 발생 알림 -->
+    <search-section @perform-search="fetchResults"></search-section>
     <Main-card-list :articles="articles"></Main-card-list>
 </template>
-
 
 <script>
 import MainCardList from "../mainpage/MainCardList.vue";

--- a/src/components/mainpage/SearchSection.vue
+++ b/src/components/mainpage/SearchSection.vue
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="input-wrapper">
       <input v-model="keyword" type="text" placeholder="Keyworld or Job title">
-      <input v-model="country" type="text" placeholder="Country">
+      <input v-model="nation" type="text" placeholder="nation">
       <button @click="search"><svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor"
           class="bi bi-search" viewBox="0 0 16 16">
           <path
@@ -20,9 +20,33 @@ export default {
       title1: "재택근무 해외이직/취업서치의 편리함",
       title2: "Fndr.io",
       keyword: "",
-      country: "",
+      nation: "",
     }
   },
+  methods: {
+    search() {
+      let query = {};
+
+      // 값이 있는 경우에만 쿼리에 키워드 추가
+      if (this.keyword && this.keyword.trim() !== "") {
+        query.keyword = this.keyword;
+      }
+
+      // 값이 있는 경우에만 쿼리에 국가를 추가
+      if (this.nation && this.nation.trim() !== "") {
+        query.nation = this.nation;
+      }
+
+    
+      this.$router.push({ name: 'search-jobs', query: query, params: { page: '1' } });
+
+      // 데이터를 fetchResults
+      this.$emit('perform-search', {
+        keyword: this.keyword,
+        nation: this.nation,
+      });
+    }
+  }
 }
 
 </script>

--- a/src/components/recruit/list/SearchList.vue
+++ b/src/components/recruit/list/SearchList.vue
@@ -22,25 +22,26 @@
 </template>
 <script>
 export default {
-    data() {
-        return {
-            articles: []
-        }
-    },
-    mounted() {
+    props: ['articles'],
+    // data() {
+    //     return {
+    //         articles: []
+    //     }
+    // },
+    // mounted() {
 
-        fetch('http://localhost:8080/rest/search/1?visa=true', {
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-            },
-        }).then(response => response.json())
-            .then(data => console.log(this.articles = data.Response.recruit_post_list
-            ))
-            .catch(error => {
-                console.error('Error fetching data:', error);
-            });
-    },
+    //     fetch('http://localhost:8080/rest/search/1?visa=true', {
+    //         headers: {
+    //             'Content-Type': 'application/json',
+    //             'Accept': 'application/json',
+    //         },
+    //     }).then(response => response.json())
+    //         .then(data => console.log(this.articles = data.Response.recruit_post_list
+    //         ))
+    //         .catch(error => {
+    //             console.error('Error fetching data:', error);
+    //         });
+    // },
 }
 
 </script>

--- a/src/components/recruit/list/SearchPage.vue
+++ b/src/components/recruit/list/SearchPage.vue
@@ -1,9 +1,61 @@
 <template>
     <div class="box">
         <search-side-bar></search-side-bar>
-        <search-list></search-list>
+        <!-- 자식컴포넌트로 데이터 전달 -->
+        <search-list :articles="results"></search-list>
     </div>
 </template>
+
+<script>
+import SearchSideBar from "../list/SearchSideBar.vue";
+import SearchList from "../list/SearchList.vue";
+export default {
+    components: {
+        SearchSideBar,
+        SearchList,
+    },
+    data() {
+        return {
+            results: [],
+        }
+    },
+    methods: {
+        // SearchSection.vue에서 보낸 emits 여기서 사용
+        fetchResults(searchParams) {
+            const currentPage = this.$route.params.page || 1;
+            const url = `http://localhost:8080/rest/search/${currentPage}?keyword=${searchParams.keyword}&nation=${searchParams.nation}`;
+
+            fetch(url, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                },
+            })
+                .then(response => response.json())
+                .then(data => {
+                    this.results = data.Response.recruit_post_list;
+                })
+                .catch(error => {
+                    console.error('Error fetching data:', error);
+                });
+        },
+        loadDataFromRoute() {
+            let searchParams = {
+                keyword: this.$route.query.keyword || '',
+                nation: this.$route.query.nation || ''
+            };
+            this.fetchResults(searchParams);
+        }
+    },
+    mounted() {
+        this.loadDataFromRoute();
+    },
+    watch: {
+        '$route.query': 'loadDataFromRoute'
+        // $route.query값이 변화 되는 것이 감지 되면 바뀐 값을 렌더링하게 함
+    },
+}
+</script>
 
 <style scoped>
 .box {
@@ -17,18 +69,3 @@
 
 }
 </style>
-
-
-<script>
-import SearchSideBar from "../list/SearchSideBar.vue";
-import SearchList from "../list/SearchList.vue";
-
-
-export default {
-    components: {
-        SearchSideBar,
-        SearchList,
-    },
-}
-
-</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,7 +8,7 @@ import DetailPage from "../components/recruit/detail/DetailPage.vue";
 // 라우터 설계
 const routes = [
   { path: "/", component: MainPage },
-  { path: "/search-jobs", component: SearchPage },
+  { path: "/search-jobs/:page", component: SearchPage, name: 'search-jobs' },
   { path: "/detail/:postId", component: DetailPage },
 
 ];


### PR DESCRIPTION
1. SearchSection.vue에서 키워드 검색하면 파라미터값 받아서 SearchPage.vue에 렌더링 되게 해놨음
2. 지금까지는 http://localhost:3000/search-jobs/1에서 1(:page) <- 이부분을 하드코딩 해놨는데 동적파라미터값 적용해서 수정함
3. 근데 아직 페이지네이션 구현안해서 페이지네이션하면서 이 부분 다시 수정 할 계획
4.  MainCardList.vue의 view more버튼이랑 TheHeader.vue에 Search jobs 연결되는 부분 수정해둠

자고일어나서 확인부탁행